### PR TITLE
Hall Monitor sends emails on Failure

### DIFF
--- a/.github/workflows/run_hall_monitor.yml
+++ b/.github/workflows/run_hall_monitor.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Check apps-dev for misinstalled interviews
     steps:
-      - uses: SuffolkLITLab/ALActions/hall_monitor@sendgrid
+      - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps-dev.suffolklitlab.org"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: bwilley@suffolk.edu,massaccess@suffolk.edu
+          ERROR_EMAILS: massaccess@suffolk.edu
       - run: echo "Finished running monitor for dev"
   apps-test-monitor:
     runs-on: ubuntu-latest
@@ -24,6 +24,8 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps-test.suffolklitlab.org"
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          ERROR_EMAILS: massaccess@suffolk.edu
       - run: echo "Finished running monitor for test"
   apps-prod-monitor:
     runs-on: ubuntu-latest
@@ -32,5 +34,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps.suffolklitlab.org"
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          ERROR_EMAILS: massaccess@suffolk.edu
       - run: echo "Finished running monitor for prod"
   

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bug fixes to the actions to immediately propagate to the AssemblyLine repos.
 
 `pythontest` sets up a python environment around the package, and runs any [`unittest` tests](https://docs.python.org/3/library/unittest.html) in the package.
 
-#### Usage 
+#### Usage
 
 ```yml
 jobs:
@@ -103,7 +103,7 @@ acting like a hall monitor peaking through doors, but not investigating any furt
 #### Usage
 
 You will likely want to run this action on a schedule, several times a day.
-You can see more about how to define this schedule in the 
+You can see more about how to define this schedule in the
 [github on.schedule](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule)
 documentation.
 
@@ -120,6 +120,22 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://my-docassemble.example.com"
+```
+
+This also supports sending email notifications (separate from GitHub's notification system, which doesn't let you notify arbitrary people about an action failing) to multiple, comma separated emails, using Sendgrid.
+
+Here's a code example:
+
+```yml
+jobs:
+  my-workflow:
+    ...
+    steps:
+      - uses: SuffolkLITLab/ALActions/hall_monitor@main
+        with:
+          SERVER_URL: "https://my-docassemble.example.com"
+          SENDGRID_API_KEY: ${{ secrets.MY_SENDGRID_API_KEY }}
+          ERROR_EMAILS: example@example.com,example2@example.com
 ```
 
 ## Development Details

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -48,23 +48,16 @@ runs:
     - if: ${{ failure() }}
       run: |
         from sendgrid import SendGridAPIClient
-        from sendgrid.helpers.mail import Mail, To, Email, From, Subject, Content
+        from sendgrid.helpers.mail import Mail
         import os
         
         if "SENDGRID_API_KEY" not in os.environ:
-            print("Not sending email to request emails")
+            print("No API key! Can't send error notification email")
             exit(0)
         if "ERROR_EMAILS" not in os.environ:
             print("No error emails passed in! Not going to notify them of this failure")
             exit(0)
 
-        message = Mail()
-        message.to = [
-          To(email=to_send, p=0) for to_send in os.environ["ERROR_EMAILS"].split(",")
-        ]
-        message.from_email = From(email="no-reply@suffolklitlab.org")
-
-        message.subject = Subject("${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}")
         content = f"""
         <p>Hey there! Your Hall Monitor Action has failed.</p>
 
@@ -79,9 +72,13 @@ runs:
         </ul>
         """
 
-        message.content = [
-          Content(mime_type="text/html", content=content)
-        ]
+        message = Mail(
+          from_email="no-reply@suffolklitlab.org",
+          to_emails=[to_send for to_send in os.environ["ERROR_EMAILS"].split(",")],
+          subject="${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}",
+          html_content=content
+        )
+
         sg = SendGridAPIClient(api_key=os.environ["SENDGRID_API_KEY"])
         resp = sg.send(message)
         print(f"{resp.status_code}, {resp.body} {resp.headers}")

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -26,7 +26,8 @@ runs:
         echo "ERROR_EMAILS=${{inputs.ERROR_EMAILS}}" >> $GITHUB_ENV
         echo "SENDGRID_API_KEY=${{inputs.SENDGRID_API_KEY}}" >> $GITHUB_ENV
       shell: bash
-    - run: |
+    - id: check_server
+      run: |
         # Beautiful soup to find failing interview links
         import bs4
         import requests
@@ -40,7 +41,10 @@ runs:
         links = soup.find_all("a")
         failed_links = [link for link in links if "dainterviewhaserror" in (link.get("class") or [])]
         if failed_links:
-            print(f"Hall Monitor found these links that aren't installed correctly: {failed_links}")
+            err_str = f"Hall Monitor found these links that aren't installed correctly: {failed_links}"
+            env_file = os.getenv('GITHUB_ENV')
+            with open(env_file, "a") as myfile:
+                myfile.write(f'ERRORED_INTERVIEWS="{err_str}"')
             exit(1)
         else:
             print(f"Hall Monitor: all good, no failed links found!")
@@ -59,22 +63,21 @@ runs:
             exit(0)
 
         content = f"""
-        <p>Hey there! Your Hall Monitor Action has failed.</p>
-
-        You should check this URL is live: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a>
-
-        More info:
+        <p>Hey there! Your Hall Monitor Action has ${{ steps.check_server.outcome }}.</p>
+        <p>You should check all of the interviews at this URL: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a></p>
+        <p>{os getenv("ERRORED_INTERVIEWS", "") }</p>
+        <p>More info:
         <ul>
-          <li> Github job: ${{ github.job }} </li>
+          <li> Github Repository: ${{ github.repository }} </li>
           <li> Github workflow: ${{ github.workflow }} </li>
-          <li> Github workflow: ${{ github.repository }} </li>
-          <li> Job status: ${{ job.status }} </li>
-        </ul>
+          <li> Github job: ${{ github.job }} </li>
+          <li> Job status: ${{ steps.check_server.outcome }} </li>
+        </ul></p>
         """
 
         message = Mail(
           from_email="no-reply@suffolklitlab.org",
-          to_emails=[to_send for to_send in os.environ["ERROR_EMAILS"].split(",")],
+          to_emails=[to_send.strip() for to_send in os.environ["ERROR_EMAILS"].split(",")],
           subject="${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}",
           html_content=content
         )

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -41,10 +41,10 @@ runs:
         links = soup.find_all("a")
         failed_links = [link for link in links if "dainterviewhaserror" in (link.get("class") or [])]
         if failed_links:
-            err_str = f"Hall Monitor found these links that aren't installed correctly: {failed_links}"
+            err_str = f"Hall Monitor found these links that aren't installed correctly: {', '.join(failed_links)}"
             env_file = os.getenv('GITHUB_ENV')
             with open(env_file, "a") as myfile:
-                myfile.write(f'ERRORED_INTERVIEWS="{err_str}"')
+                myfile.write(f'ERRORED_INTERVIEWS={err_str}')
             exit(1)
         else:
             print(f"Hall Monitor: all good, no failed links found!")
@@ -63,7 +63,7 @@ runs:
             exit(0)
 
         content = f"""
-        <p>Hey there! Your Hall Monitor Action has ${{ steps.check_server.outcome }}.</p>
+        <p>Hey there! Your Hall Monitor Action has a status of ${{ steps.check_server.outcome }}.</p>
         <p>You should check all of the interviews at this URL: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a></p>
         <p>{os.getenv('ERRORED_INTERVIEWS', '') }</p>
         <p>More info:

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -65,7 +65,7 @@ runs:
         content = f"""
         <p>Hey there! Your Hall Monitor Action has ${{ steps.check_server.outcome }}.</p>
         <p>You should check all of the interviews at this URL: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a></p>
-        <p>{os getenv("ERRORED_INTERVIEWS", "") }</p>
+        <p>{os.getenv('ERRORED_INTERVIEWS', '') }</p>
         <p>More info:
         <ul>
           <li> Github Repository: ${{ github.repository }} </li>

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -24,7 +24,7 @@ runs:
     - run: |
         echo "SERVER_URL=${{inputs.SERVER_URL}}" >> $GITHUB_ENV
         echo "ERROR_EMAILS=${{inputs.ERROR_EMAILS}}" >> $GITHUB_ENV
-        echo "SENDGRID_API_KEY=${{inputs.SENDGRID_API_KEY}}" > $GITHUB_ENV
+        echo "SENDGRID_API_KEY=${{inputs.SENDGRID_API_KEY}}" >> $GITHUB_ENV
       shell: bash
     - run: |
         # Beautiful soup to find failing interview links

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -6,6 +6,12 @@ inputs:
   SERVER_URL:
     description: "The url of the docassemble server that you want to check (with or without trailing slash)"
     required: true
+  SENDGRID_API_KEY:
+    description: "The API Key of a sendgrid account; used to send email notifications when things fail"
+    required: false
+  ERROR_EMAILS:
+    description: "A comma separated list of emails that should be notified when / if this task fails"
+    required: false
 
 runs:
   using: "composite"
@@ -13,9 +19,12 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-    - run:  pip install bs4 requests
+    - run: pip install bs4 requests sendgrid
       shell: bash
-    - run: echo "SERVER_URL=${{inputs.SERVER_URL}}" >> $GITHUB_ENV
+    - run: |
+        echo "SERVER_URL=${{inputs.SERVER_URL}}" >> $GITHUB_ENV
+        echo "ERROR_EMAILS=${{inputs.ERROR_EMAILS}}" >> $GITHUB_ENV
+        echo "SENDGRID_API_KEY=${{inputs.SENDGRID_API_KEY}}" > $GITHUB_ENV
       shell: bash
     - run: |
         # Beautiful soup to find failing interview links
@@ -35,5 +44,46 @@ runs:
             exit(1)
         else:
             print(f"Hall Monitor: all good, no failed links found!")
+      shell: python
+    - if: ${{ failure() }}
+      run: |
+        from sendgrid import SendGridAPIClient
+        from sendgrid.helpers.mail import Mail, To, Email, From, Subject, Content
+        import os
+        
+        if "SENDGRID_API_KEY" not in os.environ:
+            print("Not sending email to request emails")
+            exit(0)
+        if "ERROR_EMAILS" not in os.environ:
+            print("No error emails passed in! Not going to notify them of this failure")
+            exit(0)
+
+        message = Mail()
+        message.to = [
+          To(email=to_send, p=0) for to_send in os.environ["ERROR_EMAILS"].split(",")
+        ]
+        message.from_email = From(email="no-reply@suffolklitlab.org")
+
+        message.subject = Subject("${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}")
+        content = f"""
+        <p>Hey there! Your Hall Monitor Action has failed.</p>
+
+        You should check this URL is live: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a>
+
+        More info:
+        <ul>
+          <li> Github job: ${{ github.job }} </li>
+          <li> Github workflow: ${{ github.workflow }} </li>
+          <li> Github workflow: ${{ github.repository }} </li>
+          <li> Job status: ${{ job.status }} </li>
+        </ul>
+        """
+
+        message.content = [
+          Content(mime_type="text/html", content=content)
+        ]
+        sg = SendGridAPIClient(api_key=os.environ["SENDGRID_API_KEY"])
+        resp = sg.send(message)
+        print(f"{resp.status_code}, {resp.body} {resp.headers}")
       shell: python
 


### PR DESCRIPTION
Lets Hall Monitor send email notifications to multiple, comma separated emails, through sendgrid. Works great, and gives you a direct link to see if the server is still down, or it was just a blip (which can occasionally happen).

Some links that I used when making this:

* https://stackoverflow.com/questions/62304258/github-actions-notifications-on-workflow-failure
* https://docs.sendgrid.com/for-developers/sending-email/quickstart-python
* https://docs.sendgrid.com/api-reference/mail-send/mail-send
* https://docs.sendgrid.com/for-developers/sending-email/v3-python-code-example