### PR TITLE
New black

### DIFF
--- a/black-formatting/action.yml
+++ b/black-formatting/action.yml
@@ -38,7 +38,7 @@ runs:
       uses: psf/black@stable
       id: action_black
       with:
-        options: "--check --extend-exclude (__init__.py|setup.py)"
+        options: "--check --diff --extend-exclude (__init__.py|setup.py)"
         src: "."
     - name: Create Pull Request
       if: steps.action_black.outputs.is_formatted == 'true' && inputs.MAKE_PR == 'true'

--- a/black-formatting/action.yml
+++ b/black-formatting/action.yml
@@ -33,12 +33,13 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check files using the black formatter
-      uses: rickstaa/action-black@v1.1.7
+      uses: psf/black@stable
       id: action_black
       with:
-        black_args: ". --extend-exclude (__init__.py|setup.py)"
+        options: "--check --extend-exclude (__init__.py|setup.py)"
+        src: "."
     - name: Create Pull Request
       if: steps.action_black.outputs.is_formatted == 'true' && inputs.MAKE_PR == 'true'
       uses: peter-evans/create-pull-request@v3

--- a/black-formatting/action.yml
+++ b/black-formatting/action.yml
@@ -38,10 +38,13 @@ runs:
       uses: psf/black@stable
       id: action_black
       with:
-        options: "--check --diff --extend-exclude (__init__.py|setup.py)"
+        options: "--extend-exclude (__init__.py|setup.py)"
         src: "."
+    - run: echo "formatted_files=$(git diff --name-only)" >> $GITHUB_OUTPUT
+      id: formatted
+      shell: bash
     - name: Create Pull Request
-      if: steps.action_black.outputs.is_formatted == 'true' && inputs.MAKE_PR == 'true'
+      if: steps.formatted.outputs.formatted_files != '' && inputs.MAKE_PR == 'true'
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
@@ -52,3 +55,6 @@ runs:
           uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
         base: ${{ github.ref_name }} # Creates pull request onto pull request or commit branch
         branch: actions/black/for_${{ github.ref_name }}
+    - if: steps.formatted.outputs.formatted_files != ''
+      run: exit 1
+      shell: bash


### PR DESCRIPTION
Seems to work pretty well, example PR made here: https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/804.

It also shows neat little summaries when it runs. Might be more useful with a diff, but can't get black to output that and actually format the files at the same time. Eh.

![Screenshot from 2023-12-12 11-47-57](https://github.com/SuffolkLITLab/ALActions/assets/6252212/9f980143-6a1d-4df6-88c5-1dd3dbfc1abf)

It will now also fail the action when the files aren't formatted, so you're less likely to merge a PR thinking that everything was formatted, not realizing that a PR had been made that you need to merge (something I've done a lot).

Fixes #19 
