### PR TITLE
Update checkout to v4 and setup-python to v5

### DIFF
--- a/black-formatting/action.yml
+++ b/black-formatting/action.yml
@@ -33,7 +33,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check files using the black formatter
       uses: psf/black@stable
       id: action_black

--- a/docsig/action.yml
+++ b/docsig/action.yml
@@ -8,8 +8,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - run: pip install docsig

--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - run: pip install bs4 requests sendgrid

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -24,9 +24,9 @@ runs:
         echo "GITHUB_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
         echo "GITHUB_SERVER=${{ github.server_url}}/${{ github.repository }}" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install pypa/build

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -12,8 +12,8 @@ runs:
       shell: bash
     - run: echo "ISUNITTEST=true" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
The main update to both actions is to use Node.js 20 as the default runtime, as [Node 16 is EOL](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

* https://github.com/actions/checkout/releases/tag/v4.0.0
    * https://github.com/actions/checkout/releases/tag/v4 is what we actually will use
* https://github.com/actions/setup-python/releases/tag/v5.0.0
    * https://github.com/actions/setup-python/releases/tag/v5 is what we actually will use 

Fixes #23 