### PR TITLE
Add build constraint file

### DIFF
--- a/publish/build-constraints.txt
+++ b/publish/build-constraints.txt
@@ -1,0 +1,4 @@
+# From https://github.com/explosion/thinc/blob/126ea7f10fe746486c8d5cf00e9e2114492a3c31/build-constraints.txt#L1C1-L2C37
+# With additional fix related to https://github.com/SuffolkLITLab/FormFyxer/issues/135
+# build version constraints for use with wheelwright + multibuild
+numpy>=1.25.0,<2.0.0; python_version>='3.9'


### PR DESCRIPTION
Numpy 2.0 doesn't play well with some requirements of our python packages, i.e. spacy and thinc, used in FormFyxer.

This change adds a build-contraint file, as inspired by https://thinc.ai/docs/install#extended, which will prevent python from trying to use numpy 2 when doing isolated builds.

Since this file is best referenced from
`https://raw.githubusercontent.com`, this commit will be merged into main first, and then a commit that references this file will be used in `publish/action.yml`.

---

Have tested locally that this works, but running:

```
PIP_CONSTRAINT=../ALActions/publish/build-constraints.txt python -m build --sdist --wheel --outdir dist
```

 both on a project that is broken by the numpy 2 stuff (FormFyxer) and one that isn't (docassemble-EFSPIntegration), and both still run correctly with this file.