### PR TITLE
Actually use build-constraints.txt

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -36,7 +36,8 @@ runs:
       run: python -m compileall . -q
       shell: bash
     - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel --outdir dist/
+      # Avoids numpy 2, which breaks some builds. See https://github.com/SuffolkLITLab/ALActions/pull/25
+      run: PIP_CONSTRAINT=https://rawgithubusercontent.com/SuffolkLITLab/ALActions/main/publish/build-constraints.txt python -m build --sdist --wheel --outdir dist/
       shell: bash
     - if: ${{ success() && startsWith(github.ref, 'refs/tags') }}
       name: Ensure github tag is the same as the pypi tag

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
     - name: Build a binary wheel and a source tarball
       # Avoids numpy 2, which breaks some builds. See https://github.com/SuffolkLITLab/ALActions/pull/25
-      run: PIP_CONSTRAINT=https://rawgithubusercontent.com/SuffolkLITLab/ALActions/main/publish/build-constraints.txt python -m build --sdist --wheel --outdir dist/
+      run: PIP_CONSTRAINT=https://raw.githubusercontent.com/SuffolkLITLab/ALActions/main/publish/build-constraints.txt python -m build --sdist --wheel --outdir dist/
       shell: bash
     - if: ${{ success() && startsWith(github.ref, 'refs/tags') }}
       name: Ensure github tag is the same as the pypi tag


### PR DESCRIPTION
Use the build-constraints.txt file when building all repos, to avoid using numpy 2 which can break spacy.

Continues on the work done in #25. 

---

Keeping this a branch and testing on https://github.com/SuffolkLITLab/FormFyxer/pull/136, until I can confirm that this fixes the issue seen there. Will merge once it does.