### PR TITLE
Adjust installation order for DA 1.6 change to implicit namespaces

### DIFF
--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -26,7 +26,7 @@ runs:
     - run: pip install -v -r `find . -name requirements.txt`
       shell: bash
     # Step 2: Install the actual package
-    - run: pip install -v --editable .
+    - run: pip install -v .
       shell: bash
     - run: python -m mypy .
       shell: bash

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -20,20 +20,22 @@ runs:
         cache-dependency-path: |
             setup.py
             **/requirements.txt
+    - run: python -m venv venv
+      shell: bash
+    - run: source venv/bin/activate
+      shell: bash            
     - run: pip install wheel
       shell: bash
-    # Step 1: Install dependencies
     - run: pip install -v -r `find . -name requirements.txt`
       shell: bash
-    # Step 2: Install the actual package
-    - run: pip install -v .
+    - run: pip install -v --editable . 
       shell: bash  
     - run: export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE
       shell: bash
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
     - if: ${{ success() }}
-      run: python -m unittest discover -s ./docassemble/ALToolbox/ -p "*.py"
+      run: python -m unittest discover
       shell: bash      
     - id: output-step
       run: echo "test-outputs=$?" >> $GITHUB_OUTPUT

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -34,8 +34,11 @@ runs:
       shell: bash
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
-    - run: mv docassemble docassemble_local
-      shell: bash    
+    - run: |
+        if [[ -f docassemble/__init__.py ]]; then
+          mv docassemble/__init__.py docassemble/__init__.py.bak
+        fi
+      shell: bash
     - run: python -m unittest discover
       shell: bash      
     - id: output-step

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -34,8 +34,8 @@ runs:
       shell: bash
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
-    - if: ${{ success() }}
-      run: python -m unittest discover
+    - run: mv docassemble docassemble_local      
+    - run: python -m unittest discover
       shell: bash      
     - id: output-step
       run: echo "test-outputs=$?" >> $GITHUB_OUTPUT

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -28,7 +28,7 @@ runs:
     # Step 2: Install the actual package
     - run: pip install -v .
       shell: bash
-    - run: python -m mypy . --exclude './docassemble/__init__.py' # Ignore the now redundant but likely present docassemble __init__.py
+    - run: python -m mypy . --exclude './build'
       shell: bash
     - if: ${{ success() }}
       run: python -m unittest discover

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -22,13 +22,10 @@ runs:
             **/requirements.txt
     - run: pip install wheel
       shell: bash
-    # Step 1: Install only docassemble.base to prepare the namespace
-    - run: pip install -v docassemble.base
-      shell: bash
-    # Step 2: Install the remaining dependencies
+    # Step 1: Install dependencies
     - run: pip install -v -r `find . -name requirements.txt`
       shell: bash
-    # Step 3: Install the actual package
+    # Step 2: Install the actual package
     - run: pip install -v --editable .
       shell: bash
     - run: python -m mypy .

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -28,11 +28,13 @@ runs:
     # Step 2: Install the actual package
     - run: pip install -v .
       shell: bash  
+    - run: export PYTHONPATH=$PYTHONPATH:$GITHUB_WORKSPACE
+      shell: bash
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
     - if: ${{ success() }}
-      run: python -m unittest discover
-      shell: bash
+      run: python -m unittest discover -s ./docassemble/ALToolbox/tests -p "*.py"
+      shell: bash      
     - id: output-step
       run: echo "test-outputs=$?" >> $GITHUB_OUTPUT
       shell: bash

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -22,7 +22,14 @@ runs:
             **/requirements.txt
     - run: pip install wheel
       shell: bash
-    - run: pip install -v --editable . -r `find . -name requirements.txt`
+    # Step 1: Install only docassemble.base to prepare the namespace
+    - run: pip install -v docassemble.base
+      shell: bash
+    # Step 2: Install the remaining dependencies
+    - run: pip install -v -r `find . -name requirements.txt`
+      shell: bash
+    # Step 3: Install the actual package
+    - run: pip install -v --editable .
       shell: bash
     - run: python -m mypy .
       shell: bash

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -28,7 +28,9 @@ runs:
     # Step 2: Install the actual package
     - run: pip install -v .
       shell: bash
-    - run: python -m mypy . --exclude './build'
+    - run: rm -rf build/
+      shell: bash      
+    - run: python -m mypy . 
       shell: bash
     - if: ${{ success() }}
       run: python -m unittest discover

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -27,10 +27,8 @@ runs:
       shell: bash
     # Step 2: Install the actual package
     - run: pip install -v .
-      shell: bash
-    - run: rm -rf build/
-      shell: bash      
-    - run: python -m mypy . 
+      shell: bash  
+    - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
     - if: ${{ success() }}
       run: python -m unittest discover

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -34,7 +34,8 @@ runs:
       shell: bash
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
-    - run: mv docassemble docassemble_local      
+    - run: mv docassemble docassemble_local
+      shell: bash    
     - run: python -m unittest discover
       shell: bash      
     - id: output-step

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -28,7 +28,7 @@ runs:
     # Step 2: Install the actual package
     - run: pip install -v .
       shell: bash
-    - run: python -m mypy .
+    - run: python -m mypy . --exclude './docassemble/__init__.py' # Ignore the now redundant but likely present docassemble __init__.py
       shell: bash
     - if: ${{ success() }}
       run: python -m unittest discover

--- a/pythontests/action.yml
+++ b/pythontests/action.yml
@@ -33,7 +33,7 @@ runs:
     - run: python -m mypy . --exclude '^build/' --explicit-package-bases
       shell: bash
     - if: ${{ success() }}
-      run: python -m unittest discover -s ./docassemble/ALToolbox/tests -p "*.py"
+      run: python -m unittest discover -s ./docassemble/ALToolbox/ -p "*.py"
       shell: bash      
     - id: output-step
       run: echo "test-outputs=$?" >> $GITHUB_OUTPUT


### PR DESCRIPTION
DA 1.6.x introduces a change from `__init__.py` to implicit namespaces.

This breaks our existing unit tests.

To solve the problem, made a few adjustments:

1. Separated the install step from the requirements install step
2. Exclude the build directory from mypy tests
3. Remove the `__init__.py`, if present, from any `docassemble` folder, for compatibility with the implicit namespace