### PR TITLE
Split hall monitor functionality into python scripts

### DIFF
--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -35,78 +35,11 @@ runs:
       shell: bash
     - id: check_server
       run: |
-        # Beautiful soup to find failing interview links
-        import bs4
-        import requests
-        import os
-        with requests.get(f"{os.environ['SERVER_URL']}/list") as conn:
-            if conn.ok:
-                soup = bs4.BeautifulSoup(conn.text, "html.parser")
-            else:
-                print(f"Hall monitor couldn't connect to {os.environ['SERVER_URL']}: {conn.status_code}")
-                exit(1)
-        links = soup.find_all("a")
-        failed_links = [link for link in links if "dainterviewhaserror" in (link.get("class") or [])]
-        if failed_links:
-            updated_links = [f"{os.environ['SERVER_URL']}/{fl.attrs['href']}" for fl in failed_links ]
-            err_str = f"Hall Monitor found these links that aren't installed correctly: {', '.join(updated_links)}"
-            env_file = os.getenv('GITHUB_ENV')
-            with open(env_file, "a") as myfile:
-                myfile.write(f'ERRORED_INTERVIEWS={err_str}')
-            exit(1)
-        else:
-            print(f"Hall Monitor: all good, no failed links found!")
-      shell: python
+        python -u ${{ github.action_path }}/hall_monitor.py
+      shell: bash 
     - if: ${{ failure() }}
       run: |
-        from sendgrid import SendGridAPIClient
-        from sendgrid.helpers.mail import Mail
-        import os
-        import requests
-
-        if not os.getenv("ERROR_EMAILS"):
-            print("No error emails passed in! Not going to notify them of this failure")
-            exit(0)
-
-        send_from = os.getenv("ERROR_EMAIL_FROM", "no-reply@suffolklitlab.org")
-        send_to = [to_send.strip() for to_send in os.environ["ERROR_EMAILS"].split(",")]
-        subject = "${{ github.job }} job of ${{ github.repository }} has ${{ steps.check_server.outcome }}"
-
-        content = f"""
-        <p>Hey there! Your Hall Monitor Action has a status of ${{ steps.check_server.outcome }}.</p>
-        <p>You should check all of the interviews at this URL: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a></p>
-        <p>{os.getenv('ERRORED_INTERVIEWS', '') }</p>
-        <p>More info:
-        <ul>
-          <li> Github Repository: ${{ github.repository }} </li>
-          <li> Github workflow: ${{ github.workflow }} </li>
-          <li> Github job: ${{ github.job }} </li>
-          <li> Job status: ${{ steps.check_server.outcome }} </li>
-        </ul></p>
-        """
-
-        if os.getenv("SENDGRID_API_KEY"):
-          message = Mail(from_email=send_from, to_emails=send_to, subject=subject, html_content=content)
-          sg = SendGridAPIClient(api_key=os.environ["SENDGRID_API_KEY"])
-          try:
-            resp = sg.send(message)
-          except Exception as e:
-            print(f"Error sending email: {e}")
-            exit(2)
-        elif os.getenv("MAILGUN_API_KEY") and os.getenv("MAILGUN_DOMAIN"):
-          url = f"https://api.mailgun.net/v3/{os.environ['MAILGUN_DOMAIN']}/messages"
-          resp = requests.post(url, auth=("api", os.environ["MAILGUN_API_KEY"]), data={
-            "from": send_from,
-            "to": send_to,
-            "subject": subject,
-            "text": "Your hall monitor action has failed",
-            "html": content
-          })
-        else:
-          print("Not sending emails, neither sendgrid or mailgun is setup!")
-          exit(2)
-
-        print(f"{resp.status_code}, {resp.body} {resp.headers}")
+        python -u ${{ github.action_path }}/send_error_email.py
       shell: python
       env:
         ERROR_EMAIL_FROM: ${{ inputs.ERROR_EMAIL_FROM }}

--- a/hall_monitor/hall_monitor.py
+++ b/hall_monitor/hall_monitor.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Beautiful soup to find failing interview links
+import bs4
+import requests
+import os
+
+def check_server(server_url):
+    with requests.get(f"{server_url}/list") as conn:
+        if conn.ok:
+            soup = bs4.BeautifulSoup(conn.text, "html.parser")
+        else:
+            print(f"Hall monitor couldn't connect to {server_url}: {conn.status_code}")
+            exit(1)
+    links = soup.find_all("a")
+    # These links are already checked by docassemble when the page is served
+    failed_links = [link for link in links if "dainterviewhaserror" in (link.get("class") or [])]
+    return failed_links
+
+def main():
+    server_url = os.environ['SERVER_URL']
+    failed_links = check_server(server_url)
+    if failed_links:
+        updated_links = [f"{server_url}{fl.attrs['href']}" for fl in failed_links ]
+        err_str = f"Hall Monitor found these links that aren't installed correctly: {', '.join(updated_links)}"
+        env_file = os.getenv('GITHUB_ENV')
+        if env_file:
+            with open(env_file, "a") as myfile:
+                myfile.write(f'ERRORED_INTERVIEWS={err_str}')
+        else:
+            print(f"{err_str} (unable to print to GitHub's environment file)")
+        exit(1)
+    else:
+        print(f"Hall Monitor: all good, no failed links found!")
+
+if __name__ == "__main__":
+    main()

--- a/hall_monitor/send_error_email.py
+++ b/hall_monitor/send_error_email.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+import os
+import requests
+
+def main():
+    if not os.getenv("ERROR_EMAILS"):
+        print("No error emails passed in! Not going to notify them of this failure")
+        return 0
+
+    send_from = os.getenv("ERROR_EMAIL_FROM", "no-reply@suffolklitlab.org")
+    send_to = [to_send.strip() for to_send in os.environ["ERROR_EMAILS"].split(",")]
+    subject = "${{ github.job }} job of ${{ github.repository }} has ${{ steps.check_server.outcome }}"
+
+    content = f"""
+        <p>Hey there! Your Hall Monitor Action has a status of ${{ steps.check_server.outcome }}.</p>
+        <p>You should check all of the interviews at this URL: <a href="{os.environ['SERVER_URL']}/list">{os.environ['SERVER_URL']}/list</a></p>
+        <p>{os.getenv('ERRORED_INTERVIEWS', '') }</p>
+        <p>More info:
+        <ul>
+          <li> Github Repository: ${{ github.repository }} </li>
+          <li> Github workflow: ${{ github.workflow }} </li>
+          <li> Github job: ${{ github.job }} </li>
+          <li> Job status: ${{ steps.check_server.outcome }} </li>
+        </ul></p>
+        """
+
+    if os.getenv("SENDGRID_API_KEY"):
+        message = Mail(
+            from_email=send_from, to_emails=send_to, subject=subject, html_content=content
+        )
+        sg = SendGridAPIClient(api_key=os.environ["SENDGRID_API_KEY"])
+        try:
+            resp = sg.send(message)
+        except Exception as e:
+            print(f"Error sending email: {e}")
+            return 2
+    elif os.getenv("MAILGUN_API_KEY") and os.getenv("MAILGUN_DOMAIN"):
+        url = f"https://api.mailgun.net/v3/{os.environ['MAILGUN_DOMAIN']}/messages"
+        resp = requests.post(
+            url,
+            auth=("api", os.environ["MAILGUN_API_KEY"]),
+            data={
+                "from": send_from,
+                "to": send_to,
+                "subject": subject,
+                "text": "Your hall monitor action has failed",
+                "html": content,
+            },
+        )
+    else:
+        print("Not sending emails, neither sendgrid or mailgun is setup!")
+        return 2
+
+    print(f"{resp.status_code}, {resp.body} {resp.headers}")
+    return 0
+
+if __name__ == "__main__":
+    return_value = main()
+    exit(return_value)


### PR DESCRIPTION
Refactor to add the ability to just check that the server's main page is running (we can't control if things in folks' dispatch list always work).