### PR TITLE
Allow Hall monitor to just check the homepage

### DIFF
--- a/.github/workflows/run_hall_monitor.yml
+++ b/.github/workflows/run_hall_monitor.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps-dev.suffolklitlab.org"
+          CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
@@ -25,6 +26,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps-test.suffolklitlab.org"
+          CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
@@ -36,6 +38,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps.suffolklitlab.org"
+          CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
@@ -47,6 +50,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://docs.lawhelpmn.org"
+          CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
@@ -58,6 +62,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://apps.vtcourtforms.org"
+          CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
@@ -69,6 +74,7 @@ jobs:
       - uses: SuffolkLITLab/ALActions/hall_monitor@main
         with:
           SERVER_URL: "https://courtguide.akcourts.gov"
+          CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           ERROR_EMAILS: massaccess@suffolk.edu
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org

--- a/hall_monitor/hall_monitor.py
+++ b/hall_monitor/hall_monitor.py
@@ -5,23 +5,35 @@ import bs4
 import requests
 import os
 
+def check_homepage(server_url):
+    with requests.get(f"{server_url}/") as conn:
+        if not conn.ok:
+            print(f"Hall monitor couldn't connect to {server_url}: {conn.status_code}")
+            return [f"{server_url}/"]
+    return []
+
 def check_server(server_url):
     with requests.get(f"{server_url}/list") as conn:
         if conn.ok:
             soup = bs4.BeautifulSoup(conn.text, "html.parser")
         else:
+            # TODO: return server_url/list as a failed_links?
             print(f"Hall monitor couldn't connect to {server_url}: {conn.status_code}")
             exit(1)
     links = soup.find_all("a")
     # These links are already checked by docassemble when the page is served
     failed_links = [link for link in links if "dainterviewhaserror" in (link.get("class") or [])]
-    return failed_links
+    return [fl.attrs['href'] for fl in failed_links]
 
 def main():
     server_url = os.environ['SERVER_URL']
-    failed_links = check_server(server_url)
+    if os.getenv('CHECK_TYPE') == 'homepage':
+        failed_links = check_homepage(server_url)
+    else:
+        failed_links = check_server(server_url)
+
     if failed_links:
-        updated_links = [f"{server_url}{fl.attrs['href']}" for fl in failed_links ]
+        updated_links = [f"{server_url}{fl}" for fl in failed_links ]
         err_str = f"Hall Monitor found these links that aren't installed correctly: {', '.join(updated_links)}"
         env_file = os.getenv('GITHUB_ENV')
         if env_file:


### PR DESCRIPTION
We've started monitoring other org's servers now that we're hosting, so we need to ensure the DA server is functioning okay, but we don't need to individually check each interview live on the server.