### PR TITLE
Add proper params to hall-monitor error email

### DIFF
--- a/hall_monitor/action.yml
+++ b/hall_monitor/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash 
     - if: ${{ failure() }}
       run: |
-        python -u ${{ github.action_path }}/send_error_email.py
+        python -u ${{ github.action_path }}/send_error_email.py "${{ github.repository }}" "${{ github.workflow }}" "${{ github.job}}" "${{ steps.check_server.outcome }}"
       shell: bash
       env:
         ERROR_EMAIL_FROM: ${{ inputs.ERROR_EMAIL_FROM }}


### PR DESCRIPTION
Passed in the values normally templated from GitHub into the `send_error_email.py` script, including the github repository, workflow, job, and outcome of the previous step.

Dead simple param passing, not the most usable, but shouldn't be used often outside of CI.

Fix #38.