### PR TITLE
Start using hall monitory for efile uptime

### DIFF
--- a/.github/workflows/efileproxy_monitor.yml
+++ b/.github/workflows/efileproxy_monitor.yml
@@ -3,45 +3,31 @@ name: EfileProxy monitoring
 on:
   workflow_dispatch:
   schedule:
-    # run once a day
+    # run thrice a day
     # * is a special character in YAML, so you have to quote the string
-    - cron: "0 8,16 * * *"
+    - cron: "0 8,12,17 * * *"
 
 jobs:
-  prod-testing:
+  prod-monitor:
     runs-on: ubuntu-latest
     name: Check efile prod
     steps:
-      - run: |
-          import requests
-          import json
-          with requests.get("https://efile.suffolklitlab.org/about") as conn:
-              if conn.ok:
-                j_about = json.loads(conn.text)
-              else:
-                print(f"Couldnt't connect to efile prod! {conn.status_code}")
-                exit(1)
-          if 'version' not in j_about:
-            print(f"Couldn't get version from the about page of efile prod?: {j_about}")
-            exit(2)
-          print(f"EfileProxy Monitoring all good; able to connect to prod's about page")
-        shell: python
-  test-testing:
+      - uses: SuffolkLITLab/ALActions/hall_monitor@main
+        with:
+          SERVER_URL: "https://efile.suffolklitlab.org/about"
+          CHECK_TYPE: "homepage"
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
+  test-monitor:
     runs-on: ubuntu-latest
     name: Check efile test
     steps:
-      - run: |
-          import requests
-          import json
-          with requests.get("https://efile-test.suffolklitlab.org/about") as conn:
-              if conn.ok:
-                j_about = json.loads(conn.text)
-              else:
-                print(f"Couldnt't connect to efile test! {conn.status_code}")
-                exit(1)
-          if 'version' not in j_about:
-            print(f"Couldn't get version from the about page of efile test?: {j_about}")
-            exit(2)
-          print(f"EfileProxy Monitoring all good; able to connect to test's about page")
-        shell: python
+      - uses: SuffolkLITLab/ALActions/hall_monitor@main
+        with:
+          SERVER_URL: "https://efile-test.suffolklitlab.org/about"
+          CHECK_TYPE: "homepage"
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
         


### PR DESCRIPTION
With the addition of the "homepage" check type in hall monitor, it's feature  equivalent to what we're doing in the efile server checks.[^1]

Bumped up the check time to 3 times a day (during business hours).

Fix #39

[^1]: we aren't parsing the JSON response of the about page and confirming that there's a version anymore, but TBH that should be fine. That page should only return a 200 if it's able to respond with a correct JSON payload.