### PR TITLE
Change monitoring emails to a variable

### DIFF
--- a/.github/workflows/efileproxy_monitor.yml
+++ b/.github/workflows/efileproxy_monitor.yml
@@ -17,7 +17,7 @@ jobs:
           SERVER_URL: "https://efile.suffolklitlab.org/about"
           CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
   test-monitor:
     runs-on: ubuntu-latest
@@ -28,6 +28,6 @@ jobs:
           SERVER_URL: "https://efile-test.suffolklitlab.org/about"
           CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
         

--- a/.github/workflows/run_hall_monitor.yml
+++ b/.github/workflows/run_hall_monitor.yml
@@ -16,7 +16,7 @@ jobs:
           SERVER_URL: "https://apps-dev.suffolklitlab.org"
           CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for dev"
   apps-test-monitor:
@@ -28,7 +28,7 @@ jobs:
           SERVER_URL: "https://apps-test.suffolklitlab.org"
           CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for test"
   apps-prod-monitor:
@@ -40,7 +40,7 @@ jobs:
           SERVER_URL: "https://apps.suffolklitlab.org"
           CHECK_TYPE: "all"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for Suffolk prod"
   mn-prod-monitor:
@@ -52,7 +52,7 @@ jobs:
           SERVER_URL: "https://docs.lawhelpmn.org"
           CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for MN prod"
   vt-prod-monitor:
@@ -64,7 +64,7 @@ jobs:
           SERVER_URL: "https://apps.vtcourtforms.org"
           CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for VT prod"
   ak-prod-monitor:
@@ -76,6 +76,6 @@ jobs:
           SERVER_URL: "https://courtguide.akcourts.gov"
           CHECK_TYPE: "homepage"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          ERROR_EMAILS: massaccess@suffolk.edu
+          ERROR_EMAILS: ${{ secrets.ERROR_NOTIFY_EMAILS }} 
           ERROR_EMAIL_FROM: no-reply@suffolklitlab.org
       - run: echo "Finished running monitor for AK prod"


### PR DESCRIPTION
Makes it easier to add multiple emails to be able to receive the error emails, and so folks don't need to put their emails into a plaintext github file.

Not a part of this PR, but I did add my own email to the `ERROR_NOTIFY_EMAILS` secret as well as the existing massaccess one.