### PR TITLE
Improvements to Word diff action; this is closer to being usable for real

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ jobs:
 
 `docsig` can be configured by using `pyproject.toml`. See [the docsig README.md](https://github.com/jshwi/docsig/tree/v0.35.0#commandline) for more info.
 
+### word_diff
+
+`word_diff` converts any changed `.docx` files into Markdown (without introducing extra hard line wraps), diffing the rendered text so reviewers can read the changes directly in GitHub.
+
+#### Usage
+
+```yml
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docx-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Diff Word documents
+        uses: SuffolkLITLab/ALActions/word_diff@main
+        with:
+          # Optional: override the base commit if needed
+          # base_ref: main
+          artifact_name: word-doc-diff
+          output_dir: word_diffs
+          summary_file: word_diff_summary.md
+```
+
+- Unified diffs are written to the job log and appended to the GitHub Actions step summary so you can skim changes without downloading artifacts.
+- HTML side-by-side diffs, plus the converted Markdown files, are uploaded as an artifact (with an `index.html` table of contents by default) for richer review.
+- The action automatically determines the correct comparison commits for pull requests and pushes. For manually dispatched runs, supply `base`/`head` inputs on the workflow or pass a `base_ref` input to the action directly.
+- To make the diff run on every push, add a `push` trigger to your workflow or follow the pattern in `.github/workflows/word_diff.yml` to toggle push/PR execution via environment variables.
+
 
 ### publish
 

--- a/word_diff/action.yml
+++ b/word_diff/action.yml
@@ -1,96 +1,81 @@
-name: DOCX Diff
+name: Diff Word Files
 description: |
-  This action compares DOCX files in a pull request with the base branch and generates a diff in HTML format.
-  The HTML diff files are uploaded as artifacts and can be viewed in the 'Artifacts' section of the workflow run.
-jobs:
-  docx-diff:
-    runs-on: ubuntu-latest
+  Compare changed Word documents by converting them to Markdown without forced line wrapping.
+  Outputs both inline diffs (in the job log and summary) and side-by-side HTML diffs as artifacts.
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
+inputs:
+  base_ref:
+    description: >-
+      Optional git reference to use as the base of the comparison. By default the action detects
+      the appropriate commit from the GitHub event (pull request base, pushed "before" commit, or
+      previous commit for manual runs).
+    required: false
+  working_directory:
+    description: Relative path to run the diff from (defaults to repository root).
+    required: false
+    default: .
+  artifact_name:
+    description: Name of the uploaded artifact bundle.
+    required: false
+    default: word-doc-diff
+  output_dir:
+    description: Directory (relative to the working directory) for storing generated diff files.
+    required: false
+    default: word_diffs
+  summary_file:
+    description: File path (relative to the working directory) where the Markdown summary is written.
+    required: false
+    default: word_diff_summary.md
+  skip_checkout:
+    description: Set to true to prevent the action from running actions/checkout internally.
+    required: false
+    default: "false"
 
-      - name: Install pandoc and npm
-        run: |
-          sudo apt-get install -y pandoc npm
-          sudo npm install -g diff2html-cli
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      if: ${{ inputs.skip_checkout != 'true' }}
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Log base branch and SHA
-        run: |
-          echo "Base branch: ${{ github.event.pull_request.base.ref }}"
-          echo "PR branch SHA: ${{ github.sha }}"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
 
-      - name: Convert Base DOCX to Markdown
-        run: |
-          mkdir -p converted/base
-          base_branch="origin/${{ github.event.pull_request.base.ref }}"
-          echo "Fetching base branch $base_branch"
-          git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          echo "Checking out base branch $base_branch"
-          git checkout $base_branch
-          for file in $(git diff --name-only ${{ github.sha }} $base_branch | grep '.docx'); do
-            echo "Converting $file from base branch"
-            if [[ -f "$file" ]]; then
-              mkdir -p "converted/base/$(dirname "$file")"
-              pandoc "$file" -t markdown -o "converted/base/${file%.docx}.md"
-              echo "Converted $file to converted/base/${file%.docx}.md"
-            else
-              echo "$file does not exist in base branch"
-            fi
-          done
+    - name: Install dependencies
+      shell: bash
+      run: pip install --disable-pip-version-check --no-input docx2python
 
-      - name: Convert PR DOCX to Markdown
-        run: |
-          mkdir -p converted/head
-          git checkout ${{ github.sha }}
-          for file in $(git diff --name-only ${{ github.sha }} origin/${{ github.event.pull_request.base.ref }} | grep '.docx'); do
-            echo "Converting $file from PR branch"
-            if [[ -f "$file" ]]; then
-              mkdir -p "converted/head/$(dirname "$file")"
-              pandoc "$file" -t markdown -o "converted/head/${file%.docx}.md"
-              echo "Converted $file to converted/head/${file%.docx}.md"
-            else
-              echo "$file does not exist in PR branch"
-            fi
-          done
+    - id: diff
+      name: Generate Word diffs
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        INPUT_BASE_REF: ${{ inputs.base_ref }}
+        WORD_DIFF_OUTPUT_DIR: ${{ inputs.output_dir }}
+        WORD_DIFF_SUMMARY_FILE: ${{ inputs.summary_file }}
+      run: |
+        python "$GITHUB_ACTION_PATH/diff_word_documents.py" \
+          --output-dir "$WORD_DIFF_OUTPUT_DIR" \
+          --summary "$WORD_DIFF_SUMMARY_FILE"
 
-      - name: Generate and Display Diff
-        run: |
-          mkdir -p diff_output
-          base_branch="origin/${{ github.event.pull_request.base.ref }}"
-          echo "# DOCX Diffs" > diff_summary.md
-          for file in $(git diff --name-only ${{ github.sha }} $base_branch | grep '.docx'); do
-            if [[ -f "converted/base/${file%.docx}.md" && -f "converted/head/${file%.docx}.md" ]]; then
-              echo "Diff for $file:"
-              mkdir -p "diff_output/$(dirname "$file")"
-              diff "converted/base/${file%.docx}.md" "converted/head/${file%.docx}.md" > "diff_output/${file%.docx}.diff" || true
-              echo "Diff output for $file:"
-              cat "diff_output/${file%.docx}.diff"
-              if [[ -s "diff_output/${file%.docx}.diff" ]]; then
-                diff2html -i file -o stdout -F "diff_output/${file%.docx}.html" -- "diff_output/${file%.docx}.diff"
-                echo "Generated HTML diff for ${file}:"
-                cat "diff_output/${file%.docx}.html"
-                echo "## Diff for ${file}" >> diff_summary.md
-              else
-                echo "No differences found for $file"
-              fi
-            else
-              echo "Converted files for $file do not exist"
-            fi
-          done
+    - name: Publish diff summary
+      if: always()
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        if [[ -f "${{ inputs.summary_file }}" ]]; then
+          cat "${{ inputs.summary_file }}" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "No Word diffs were generated." >> "$GITHUB_STEP_SUMMARY"
+        fi
 
-      - name: Upload Diff Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: docx-diff
-          path: diff_output/
-
-      - name: Add Diff Links to Job Summary
-        if: always()
-        run: |
-          echo "# DOCX Diffs" > $GITHUB_STEP_SUMMARY
-          echo "The diff files have been generated and uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
-          echo "You can download and view the diff files from the 'Artifacts' section in this workflow run." >> $GITHUB_STEP_SUMMARY
-          cat diff_summary.md >> $GITHUB_STEP_SUMMARY
+    - name: Upload diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.working_directory }}/${{ inputs.output_dir }}
+        if-no-files-found: warn

--- a/word_diff/diff_word_documents.py
+++ b/word_diff/diff_word_documents.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Generate diffs for DOCX files using docx2python.
+
+The script compares Word documents between two git revisions, converts them to
+Markdown-like text without forced line wrapping, and emits both unified and
+HTML side-by-side diffs. Designed for use inside GitHub Actions so the diffs
+appear in logs, the step summary, and as downloadable artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import pathlib
+import subprocess
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+from docx2python import docx2python
+from docx2python.depth_collector import Par, Run
+
+
+@dataclass
+class DocxMarkdown:
+    path: pathlib.Path
+    markdown: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate DOCX diffs")
+    parser.add_argument(
+        "--base",
+        help="Base git ref/sha for comparison (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--head",
+        help="Head git ref/sha for comparison (default: current GitHub SHA)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="word_diffs",
+        help="Directory to store diff artifacts (default: word_diffs)",
+    )
+    parser.add_argument(
+        "--summary",
+        default="word_diff_summary.md",
+        help="Path to a Markdown summary file",
+    )
+    return parser.parse_args()
+
+
+def run_git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed with code {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def list_changed_docx(base: str, head: str) -> List[str]:
+    stdout = run_git("diff", "--name-only", base, head, "--", "*.docx")
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def file_exists_at(ref: str, path: str) -> bool:
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}:{path}"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def read_file_at(ref: str, path: str) -> Optional[bytes]:
+    if not file_exists_at(ref, path):
+        return None
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def normalize_whitespace(value: str) -> str:
+    return " ".join(value.replace("\r", " ").replace("\n", " ").split())
+
+
+def flatten_strings(node: Sequence | str) -> Iterator[str]:
+    if isinstance(node, str):
+        cleaned = normalize_whitespace(node)
+        if cleaned:
+            yield cleaned
+        return
+    for item in node:
+        if isinstance(item, (list, tuple)):
+            yield from flatten_strings(item)
+        else:
+            text = normalize_whitespace(str(item))
+            if text:
+                yield text
+
+
+def iter_paragraphs(structure: Sequence) -> Iterator[Par]:
+    stack: List = list(structure)[::-1]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, Par):
+            yield item
+        elif isinstance(item, list):
+            stack.extend(item[::-1])
+
+
+def block_is_table(block_pars: Sequence) -> bool:
+    return any("tbl" in (par.lineage or ()) for par in iter_paragraphs(block_pars))
+
+
+def run_to_markdown(run: Run) -> str:
+    text = normalize_whitespace(run.text)
+    if not text:
+        return ""
+
+    styles = set(run.html_style or [])
+    prefix = suffix = ""
+    if "b" in styles and "i" in styles:
+        prefix = suffix = "***"
+    elif "b" in styles:
+        prefix = suffix = "**"
+    elif "i" in styles:
+        prefix = suffix = "*"
+    elif "u" in styles:
+        prefix = suffix = "__"
+
+    return f"{prefix}{text}{suffix}"
+
+
+def paragraph_to_markdown(paragraph: Par) -> str:
+    pieces = [piece for piece in (run_to_markdown(run) for run in paragraph.runs) if piece]
+    text = " ".join(pieces).strip()
+    if not text:
+        return ""
+
+    style = (paragraph.style or "").lower()
+    if style.startswith("heading"):
+        digits = "".join(ch for ch in paragraph.style if ch.isdigit())
+        level = int(digits) if digits.isdigit() else 1
+        level = max(1, min(level, 6))
+        return f"{'#' * level} {text}"
+    if "list" in style:
+        prefix = "- "
+        if "number" in style or "decimal" in style:
+            prefix = "1. "
+        return f"{prefix}{text}"
+
+    return text
+
+
+def table_block_to_markdown(block: Sequence[Sequence]) -> str:
+    table_rows: List[List[str]] = []
+    for row in block:
+        cells: List[str] = []
+        for cell in row:
+            cell_text = " ".join(flatten_strings(cell)).strip()
+            cells.append(cell_text)
+        if cells:
+            table_rows.append(cells)
+
+    if not table_rows:
+        return ""
+
+    width = max(len(row) for row in table_rows)
+    for row in table_rows:
+        if len(row) < width:
+            row.extend([""] * (width - len(row)))
+
+    header = table_rows[0]
+    divider = "| " + " | ".join(["---"] * width) + " |"
+    md_lines = ["| " + " | ".join(header) + " |", divider]
+    for row in table_rows[1:]:
+        md_lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(md_lines)
+
+
+def convert_docx_to_markdown(data: bytes, file_path: str) -> DocxMarkdown:
+    lines: List[str] = []
+    with docx2python(BytesIO(data), html=True) as document:
+        for block, block_pars in zip(document.body, document.body_pars):
+            if block_is_table(block_pars):
+                table_md = table_block_to_markdown(block)
+                if table_md:
+                    lines.append(table_md)
+                continue
+
+            for paragraph in iter_paragraphs(block_pars):
+                md = paragraph_to_markdown(paragraph)
+                if md:
+                    lines.append(md)
+
+    markdown = "\n\n".join(lines).strip()
+    return DocxMarkdown(path=pathlib.Path(file_path), markdown=markdown)
+
+
+def unified_diff(label: str, base_md: Optional[str], head_md: Optional[str]) -> str:
+    from difflib import unified_diff as udiff
+
+    base_lines = (base_md or "").splitlines()
+    head_lines = (head_md or "").splitlines()
+    diff = udiff(base_lines, head_lines, fromfile=f"a/{label}", tofile=f"b/{label}", lineterm="")
+    return "\n".join(diff)
+
+
+def html_diff(label: str, base_md: Optional[str], head_md: Optional[str]) -> str:
+    from difflib import HtmlDiff
+
+    base_lines = (base_md or "").splitlines()
+    head_lines = (head_md or "").splitlines()
+    return HtmlDiff(wrapcolumn=160).make_file(base_lines, head_lines, f"a/{label}", f"b/{label}")
+
+
+def ensure_dir(path: pathlib.Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def determine_refs(base_arg: Optional[str], head_arg: Optional[str]) -> Tuple[str, str]:
+    head = head_arg or os.environ.get("GITHUB_SHA")
+    base = base_arg or os.environ.get("INPUT_BASE_REF")
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+
+    if (not base or base == "") and event_path and pathlib.Path(event_path).exists():
+        with open(event_path, "r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+        if event_name == "pull_request":
+            base = payload.get("pull_request", {}).get("base", {}).get("sha")
+        elif event_name == "push":
+            base = payload.get("before")
+        elif event_name == "workflow_dispatch":
+            inputs = payload.get("inputs", {})
+            base = inputs.get("base") or payload.get("before")
+            head = inputs.get("head") or head
+
+    if not head:
+        head = run_git("rev-parse", "HEAD").strip()
+
+    if not base:
+        base = run_git("rev-parse", "HEAD^1").strip()
+
+    return base, head
+
+
+def main() -> None:
+    args = parse_args()
+    base, head = determine_refs(args.base, args.head)
+
+    output_dir = pathlib.Path(args.output_dir)
+    ensure_dir(output_dir)
+
+    summary_path = pathlib.Path(args.summary)
+    changed = list_changed_docx(base, head)
+
+    if not changed:
+        message = "No DOCX changes detected between the selected revisions."
+        print(message)
+        summary_path.write_text(message + "\n", encoding="utf-8")
+        return
+
+    summary_lines: List[str] = ["# Word document diffs", ""]
+    html_index: List[str] = ["<h1>Word document diffs</h1>", "<p>Markdown conversion diff results.</p>", "<ul>"]
+
+    for file in changed:
+        base_bytes = read_file_at(base, file)
+        head_bytes = read_file_at(head, file)
+
+        base_md = convert_docx_to_markdown(base_bytes, file).markdown if base_bytes else None
+        head_md = convert_docx_to_markdown(head_bytes, file).markdown if head_bytes else None
+
+        diff_text = unified_diff(file, base_md, head_md)
+        diff_path = output_dir / f"{file}.diff"
+        ensure_dir(diff_path.parent)
+        diff_path.write_text(diff_text + "\n", encoding="utf-8")
+
+        html_body = html_diff(file, base_md, head_md)
+        html_path = output_dir / f"{file}.html"
+        html_path.write_text(html_body, encoding="utf-8")
+
+        if base_md is not None:
+            (output_dir / f"{file}.base.md").write_text(base_md + "\n", encoding="utf-8")
+        if head_md is not None:
+            (output_dir / f"{file}.head.md").write_text(head_md + "\n", encoding="utf-8")
+
+        print(f"\n===== Diff for {file} =====")
+        if diff_text.strip():
+            print(diff_text)
+        else:
+            print("No textual differences detected after conversion.")
+
+        summary_lines.append(f"## {file}")
+        summary_lines.append("````diff")
+        summary_lines.append(diff_text or "No differences detected")
+        summary_lines.append("````")
+        summary_lines.append("")
+
+        html_index.append(
+            f"  <li><a href='{html.escape(file)}.html'>{html.escape(file)}</a></li>"
+        )
+
+    html_index.append("</ul>")
+    (output_dir / "index.html").write_text("\n".join(html_index), encoding="utf-8")
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
1. Switched to using Python; easier for us to maintain going forward.
2. Actually show a preview of the diff as an artifact that you can easily view in the Action summary.

Example: https://github.com/SuffolkLITLab/docassemble-MALemonLawLetter/actions/runs/18107697107?pr=4

<img width="1650" height="1141" alt="image" src="https://github.com/user-attachments/assets/22e6e195-a3d8-4611-b059-91d57f756d66" />
