### PR TITLE
Remove 7 day embargo for DAYamlChecker

### DIFF
--- a/da_build/action.yml
+++ b/da_build/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
 
     - name: Install dependencies
-      run: uv tool install "dayamlchecker>=1.2.0"
+      run: uv tool install "dayamlchecker>=1.4.0" --exclude-newer-package "dayamlchecker=0 days"
       shell: bash
 
     - name: Check syntax for all files


### PR DESCRIPTION
Doing a lot of quality of life updates to DAYamlChecker; I think it makes sense to be able to e.g., reduce noisy findings/reclassify errors as warnings right away, since it's otherwise a blocker for merging PRs across all of our repos.

can take our time to decide this.